### PR TITLE
Remove unused `emoji-data-css` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
     "mini-css-extract-plugin": "^0.4.5",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "resolve-url-loader": "^3.0.0",
+    "sass": "^1.50.1",
     "sass-loader": "^7.1.0",
     "uglifyjs-webpack-plugin": "^2.1.0",
     "url-loader": "^1.1.2",
     "webpack": "^4.28.2",
-    "webpack-cli": "^3.1.2",
-    "sass": "^1.50.1"
+    "webpack-cli": "^3.1.2"
   },
   "scripts": {
     "build": "webpack"
@@ -40,7 +40,6 @@
   },
   "homepage": "https://github.com/contentco/quill-emoji#readme",
   "dependencies": {
-    "emoji-data-css": "^1.0.1",
     "fuse.js": "^3.3.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1113,11 +1113,6 @@ alphanum-sort@^1.0.0:
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
   integrity sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=
 
-amdefine@>=0.0.4:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
-  integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
-
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -1790,14 +1785,6 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-clean-css@^3.4.20:
-  version "3.4.28"
-  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-3.4.28.tgz#bf1945e82fc808f55695e6ddeaec01400efd03ff"
-  integrity sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=
-  dependencies:
-    commander "2.8.x"
-    source-map "0.4.x"
-
 cliui@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
@@ -1872,13 +1859,6 @@ color@^3.0.0:
   dependencies:
     color-convert "^1.9.3"
     color-string "^1.6.0"
-
-commander@2.8.x:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.8.1.tgz#06be367febfda0c330aa1e2a072d3dc9762425d4"
-  integrity sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=
-  dependencies:
-    graceful-readlink ">= 1.0.0"
 
 commander@^2.20.0, commander@^2.8.1:
   version "2.20.3"
@@ -2509,19 +2489,6 @@ elliptic@^6.5.3:
     inherits "^2.0.4"
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
-
-emoji-data-css@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/emoji-data-css/-/emoji-data-css-1.0.1.tgz#4f95b48394b58571ed3284acfa709ea511875f8f"
-  integrity sha1-T5W0g5S1hXHtMoSs+nCepRGHX48=
-  dependencies:
-    clean-css "^3.4.20"
-    emoji-datasource "^2.4.4"
-
-emoji-datasource@^2.4.4:
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/emoji-datasource/-/emoji-datasource-2.4.4.tgz#b97ac1896bc208ecf1833564a20687a5215d0389"
-  integrity sha1-uXrBiWvCCOzxgzVkogaHpSFdA4k=
 
 emoji-regex@^7.0.1:
   version "7.0.3"
@@ -3265,11 +3232,6 @@ graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
-
-"graceful-readlink@>= 1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
-  integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -5926,13 +5888,6 @@ source-map-url@^0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.1.tgz#0af66605a745a5a2f91cf1bbf8a7afbc283dec56"
   integrity sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==
-
-source-map@0.4.x:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
-  integrity sha1-66T12pwNyZneaAMti092FzZSA2s=
-  dependencies:
-    amdefine ">=0.0.4"
 
 source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"


### PR DESCRIPTION
## Summary
Remove unused `emoji-data-css` npm package. It looks like it was used long time ago in `demo/index.html` file ([ref](https://github.com/contentco/quill-emoji/commit/be3d170924d8c16ec1e4f622d8c263f3bd1eace7#diff-b18ccd15ec95e2a9c4fead5bca9085042af688361a24d3463c27138e3c797a5b)), but then in the next commit the usage was removed, but the package left 🤦  ([ref](https://github.com/contentco/quill-emoji/commit/9b09d942c64f43826daeb52a899dd8c7566697d5#diff-b18ccd15ec95e2a9c4fead5bca9085042af688361a24d3463c27138e3c797a5b)).

This package also makes `nathantreid:css-modules` atmosphere package in Analytics app acting abnormal: it keeps rebuilding css files from `emoji-data-css` package on every change in the Analytics codebase. And removal of this package fixes the issue.

### Shortcut Story Link(s)
https://app.shortcut.com/maestroqa/story/86730/improve-meteor-app-re-build-time

### Testing / Replication Steps
1. Make sure that `yarn build` command works, and resulting files in `dist` folder are equal to the current ones.
2. Go to this package folder and run `npm link` command to create a symlink to `quill-emoji` package.
3. Go to Analytics app folder, run `rm -rf node_modules/quill-emoji` and `rm -rf node_modules/emoji-data-css` to remove the packages.
4. Run `npm link quill-emoji` to use local version of this package in Analytics app.
5. Run Analytics app, make sure that emojis in RichTextEditor in Coaching form work as expected.

Also, the rebuilding duration of Analytics app should improve, and the size of `.meteor/local/plugin-cache/nathantreid_css-modules` folder should stop growing after rebuilding the app.