### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-emoji",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Quill Extension for Emoji Selection",
   "main": "dist/quill-emoji.js",
   "devDependencies": {


### PR DESCRIPTION
# Summary
I removed `emoji-data-css` dependency from this package **2 weeks** ago (https://github.com/adtribute/quill-emoji/pull/6), then I correspondingly removed `emoji-data-css` from `package-lock.json` in Analytics repo (https://github.com/adtribute/analytics/pull/13517), and yet in one of the latest dependabot PRs the `emoji-data-css` dependency got back to Analytics repo (https://github.com/adtribute/analytics/pull/13531/files#diff-053150b640a7ce75eff69d1a22cae7f0f94ad64ce9a855db544dda0929316519). I assume that it's because I haven't bumped this package's version, thus dependabot fetches this package from cache instead of the repo. Let's try to bump the version of this package and see how it goes on this Wednesday